### PR TITLE
Check if new_data in removeDoubleQuotes function is empty

### DIFF
--- a/addon/doxyparse/doxyparse.cpp
+++ b/addon/doxyparse/doxyparse.cpp
@@ -173,7 +173,7 @@ static int isPartOfCStruct(MemberDef * md) {
 std::string removeDoubleQuotes(std::string data) {
   QCString new_data = QCString(data.c_str());
   new_data.replace(QRegExp("\""), "");
-  return new_data.data();
+  return !new_data.isEmpty() ? new_data.data() : "";
 }
 
 std::string argumentData(Argument *argument) {


### PR DESCRIPTION
Closes https://github.com/analizo/analizo/issues/120

Doxyparse receives a `SIGABRT` and is terminated when analyzes [mlpack](https://github.com/mlpack/mlpack.git) source code, it is happening when `removeDoubleQuotes` function is called with a string with `"/"/""` content passed by argument.

`QCString::data()` method returns a `const char` NULL pointer when is an empty `QCString` and `removeDoubleQuotes` function returns a `std::string` object type, it is not possible to instantiate a `std::string` with a NULL pointer, so to fix it was only necessary check if `new_data` is empty, if is not empty the function returns `new_data.data()`, if is empty the function returns an empty `std::string`.

gdb's output:

```C++
(gdb) bt
#0  0x00007ffff6f84428 in __GI_raise (sig=sig@entry=6)
    at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007ffff6f8602a in __GI_abort () at abort.c:89
#2  0x00007ffff78c784d in __gnu_cxx::__verbose_terminate_handler() ()
   from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#3  0x00007ffff78c56b6 in ?? () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#4  0x00007ffff78c5701 in std::terminate() ()
   from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#5  0x00007ffff78c5919 in __cxa_throw ()
   from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#6  0x00007ffff78ee14f in std::__throw_logic_error(char const*) ()
   from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#7  0x00007ffff7959a94 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) () from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#8  0x00007ffff7959c4c in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) ()
   from /usr/lib/x86_64-linux-gnu/libstdc++.so.6
#9  0x0000000000404a0f in removeDoubleQuotes (data="\"\"")
    at doxyparse/addon/doxyparse/doxyparse.cpp:176
#10 0x0000000000404b94 in argumentData[abi:cxx11](Argument*) (argument=0x2edfc20)
    at doxyparse/addon/doxyparse/doxyparse.cpp:182
#11 0x0000000000404f07 in functionSignature[abi:cxx11](MemberDef*) (md=0x2eddbf0)
    at doxyparse/addon/doxyparse/doxyparse.cpp:199
#12 0x0000000000405c1b in lookupSymbol (d=0x2eddbf0)
    at doxyparse/addon/doxyparse/doxyparse.cpp:267
#13 0x0000000000405e6b in listMembers (ml=0x2edefe0)
    at doxyparse/addon/doxyparse/doxyparse.cpp:283
#14 0x0000000000406abf in listSymbols ()
    at doxyparse/addon/doxyparse/doxyparse.cpp:364
#15 0x00000000004070ac in main (argc=2, argv=0x7fffffffde88)
    at doxyparse/addon/doxyparse/doxyparse.cpp:474
```