### PR TITLE
Auto Github release creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 /doxygen_docs
 /doxygen.tag
+auth-token

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ compiler:
 before_install:
     - sudo apt-add-repository ppa:smspillaz/cmake-2.8.12 -y
     - sudo apt-get update -qq
+    - openssl aes-256-cbc -K $encrypted_f4b786671656_key -iv $encrypted_f4b786671656_iv -in auth-token.enc -out auth-token -d
 
 install:
     - sudo apt-get install -qq texlive
@@ -21,3 +22,10 @@ script:
     - make
     - make tests
     - make docs
+
+deploy:
+    # Deploys to Doxyparse official GitHub
+    provider: script
+    script: sh scripts/create-gh-release.sh
+    on:
+        branch: master

--- a/scripts/sh/create-gh-release.sh
+++ b/scripts/sh/create-gh-release.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+VERSION=$(cat ../../VERSION)
+REPO_FULL_NAME=$(git config --get remote.origin.url | sed 's/.*:\/\/github.com\///;s/.git$//')
+TEXT="Deploying version $VERSION of $REPO_FULL_NAME"
+TOKEN_SHA=$(cat ../../auth-token)
+REPO_URL=https://api.github.com/repos/$REPO_FULL_NAME/releases?access_token=$TOKEN_SHA
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Sample JSON pattern accepted by GitHub API
+generate_post_data()
+{
+cat <<EOF
+{
+  "tag_name": "$VERSION",
+  "target_commitish": "$BRANCH",
+  "name": "$VERSION",
+  "body": "$TEXT",
+  "draft": false,
+  "prerelease": false
+}
+EOF
+}
+
+# Posting Sample JSON to GitHub API using required token and credentials
+echo "Creating Release v$VERSION for $REPO_FULL_NAME"
+curl --data "$(generate_post_data)" $REPO_URL


### PR DESCRIPTION
This enables the creation of a GH simple release, cointaning the source code wrapped in a tar.gz. Later on I'll open a PR enabling pushing assets aggregating to the latest release the executable .deb and tar.gz