### PR TITLE
"Do not count/print 'void' as a function argument."

### DIFF
--- a/addon/doxyparse/doxyparse.cpp
+++ b/addon/doxyparse/doxyparse.cpp
@@ -264,12 +264,22 @@ static bool checkOverrideArg(ArgumentList *argList, MemberDef *md) {
 }
 
 void functionInformation(MemberDef* md) {
+  std::string temp = "";
   int size = md->getEndBodyLine() - md->getStartBodyLine() + 1;
   printNumberOfLines(size);
   ArgumentList *argList = md->argumentList();
+
   if (argList) {
-    printNumberOfArguments(argList->count());
+      ArgumentListIterator iterator(*argList);
+      Argument * argument = iterator.toFirst();
+      if(argument != NULL) {
+        temp = argumentData(argument);
+          if(temp != "void") {
+              printNumberOfArguments(argList->count());
+          }
+      }
   }
+
   printNumberOfConditionalPaths(md);
   MemberSDict *defDict = md->getReferencesMembers();
   if (defDict) {

--- a/addon/doxyparse/doxyparse.cpp
+++ b/addon/doxyparse/doxyparse.cpp
@@ -274,6 +274,7 @@ void functionInformation(MemberDef* md) {
       Argument * argument = iterator.toFirst();
       if(argument != NULL) {
         temp = argumentData(argument);
+// TODO: This is a workaround; better not include "void" in argList, in the first place. 
           if(temp != "void") {
               printNumberOfArguments(argList->count());
           }


### PR DESCRIPTION
Before:

      - "setup(void)":
          type: function
          line: 67
          protection: public
          lines_of_code: 11
          **parameters: 1**.  WRONG!
          conditional_paths: 2

AFTER:

      - "setup(void)":
          type: function
          line: 67
          protection: public
          lines_of_code: 11
          conditional_paths: 2
